### PR TITLE
CSV Export fixes

### DIFF
--- a/bindings/dart/test/database_csv_test.dart
+++ b/bindings/dart/test/database_csv_test.dart
@@ -58,15 +58,22 @@ void main() {
           'label': 'Item1',
           'name': 'Alpha',
         });
+        final id2 = db.createElement('Items', {
+          'label': 'Item2',
+          'name': 'Beta',
+        });
         db.updateVectorFloats('Items', 'measurement', id1, [1.1, 2.2, 3.3]);
+        db.updateVectorFloats('Items', 'measurement', id2, [4.4, 5.5]);
 
         db.exportCSV('Items', 'measurements', csvPath);
         final content = File(csvPath).readAsStringSync();
 
-        expect(content, contains('label,measurement\n'));
-        expect(content, contains('Item1,1.1\n'));
-        expect(content, contains('Item1,2.2\n'));
-        expect(content, contains('Item1,3.3\n'));
+        expect(content, contains('sep=,\nid,vector_index,measurement\n'));
+        expect(content, contains('Item1,1,1.1\n'));
+        expect(content, contains('Item1,2,2.2\n'));
+        expect(content, contains('Item1,3,3.3\n'));
+        expect(content, contains('Item2,1,4.4\n'));
+        expect(content, contains('Item2,2,5.5\n'));
       } finally {
         final f = File(csvPath);
         if (f.existsSync()) f.deleteSync();

--- a/bindings/julia/test/test_database_csv.jl
+++ b/bindings/julia/test/test_database_csv.jl
@@ -49,15 +49,22 @@ include("fixture.jl")
                 label = "Item1",
                 name = "Alpha",
             )
+            id2 = Quiver.create_element!(db, "Items";
+                label = "Item2",
+                name = "Beta",
+            )
             Quiver.update_vector_floats!(db, "Items", "measurement", id1, [1.1, 2.2, 3.3])
+            Quiver.update_vector_floats!(db, "Items", "measurement", id2, [4.4, 5.5])
 
             Quiver.export_csv(db, "Items", "measurements", csv_path)
             content = read(csv_path, String)
 
-            @test occursin("label,measurement\n", content)
-            @test occursin("Item1,1.1\n", content)
-            @test occursin("Item1,2.2\n", content)
-            @test occursin("Item1,3.3\n", content)
+            @test occursin("sep=,\nid,vector_index,measurement\n", content)
+            @test occursin("Item1,1,1.1\n", content)
+            @test occursin("Item1,2,2.2\n", content)
+            @test occursin("Item1,3,3.3\n", content)
+            @test occursin("Item2,1,4.4\n", content)
+            @test occursin("Item2,2,5.5\n", content)
         finally
             isfile(csv_path) && rm(csv_path)
             Quiver.close!(db)

--- a/tests/test_database_csv.cpp
+++ b/tests/test_database_csv.cpp
@@ -76,20 +76,27 @@ TEST(DatabaseCSV, ExportCSV_VectorGroupExport) {
     e1.set("label", std::string("Item1")).set("name", std::string("Alpha"));
     auto id1 = db.create_element("Items", e1);
 
+    quiver::Element e2;
+    e2.set("label", std::string("Item2")).set("name", std::string("Beta"));
+    auto id2 = db.create_element("Items", e2);
+
     db.update_vector_floats("Items", "measurement", id1, {1.1, 2.2, 3.3});
+    db.update_vector_floats("Items", "measurement", id2, {4.4, 5.5});
 
     auto csv_path = temp_csv("VectorExport");
     db.export_csv("Items", "measurements", csv_path.string());
 
     auto content = read_file(csv_path.string());
 
-    // Header: label + value columns (no id, no vector_index)
-    EXPECT_NE(content.find("label,measurement\n"), std::string::npos);
+    // Header: id + vector_index + value columns
+    EXPECT_NE(content.find("sep=,\nid,vector_index,measurement\n"), std::string::npos);
 
-    // Data rows: one row per vector element
-    EXPECT_NE(content.find("Item1,1.1\n"), std::string::npos);
-    EXPECT_NE(content.find("Item1,2.2\n"), std::string::npos);
-    EXPECT_NE(content.find("Item1,3.3\n"), std::string::npos);
+    // Data rows: one row per vector element with vector_index
+    EXPECT_NE(content.find("Item1,1,1.1\n"), std::string::npos);
+    EXPECT_NE(content.find("Item1,2,2.2\n"), std::string::npos);
+    EXPECT_NE(content.find("Item1,3,3.3\n"), std::string::npos);
+    EXPECT_NE(content.find("Item2,1,4.4\n"), std::string::npos);
+    EXPECT_NE(content.find("Item2,2,5.5\n"), std::string::npos);
 
     fs::remove(csv_path);
 }
@@ -108,8 +115,8 @@ TEST(DatabaseCSV, ExportCSV_SetGroupExport) {
 
     auto content = read_file(csv_path.string());
 
-    // Header: label + tag
-    EXPECT_NE(content.find("label,tag\n"), std::string::npos);
+    // Header: id + tag
+    EXPECT_NE(content.find("sep=,\nid,tag\n"), std::string::npos);
 
     // Data rows
     EXPECT_NE(content.find("Item1,red\n"), std::string::npos);
@@ -136,8 +143,8 @@ TEST(DatabaseCSV, ExportCSV_TimeSeriesGroupExport) {
 
     auto content = read_file(csv_path.string());
 
-    // Header: label + dimension + value columns
-    EXPECT_NE(content.find("label,date_time,temperature,humidity\n"), std::string::npos);
+    // Header: id + dimension + value columns
+    EXPECT_NE(content.find("sep=,\nid,date_time,temperature,humidity\n"), std::string::npos);
 
     // Data rows ordered by date_time
     EXPECT_NE(content.find("Item1,2024-01-01T10:00:00,22.5,60\n"), std::string::npos);

--- a/tests/test_lua_runner.cpp
+++ b/tests/test_lua_runner.cpp
@@ -2055,17 +2055,21 @@ TEST(LuaRunner_ExportCSV, GroupExport) {
     auto csv_path = lua_csv_temp("GroupExport");
 
     lua.run(R"(
-        local id = db:create_element("Items", { label = "Item1", name = "Alpha" })
-        db:update_vector_floats("Items", "measurement", id, {1.1, 2.2, 3.3})
+        local id1 = db:create_element("Items", { label = "Item1", name = "Alpha" })
+        local id2 = db:create_element("Items", { label = "Item2", name = "Beta" })
+        db:update_vector_floats("Items", "measurement", id1, {1.1, 2.2, 3.3})
+        db:update_vector_floats("Items", "measurement", id2, {4.4, 5.5})
     )");
 
     lua.run("db:export_csv(\"Items\", \"measurements\", \"" + lua_safe_path(csv_path) + "\")");
 
     auto content = read_csv_file(csv_path.string());
-    EXPECT_NE(content.find("label,measurement\n"), std::string::npos);
-    EXPECT_NE(content.find("Item1,1.1\n"), std::string::npos);
-    EXPECT_NE(content.find("Item1,2.2\n"), std::string::npos);
-    EXPECT_NE(content.find("Item1,3.3\n"), std::string::npos);
+    EXPECT_NE(content.find("sep=,\nid,vector_index,measurement\n"), std::string::npos);
+    EXPECT_NE(content.find("Item1,1,1.1\n"), std::string::npos);
+    EXPECT_NE(content.find("Item1,2,2.2\n"), std::string::npos);
+    EXPECT_NE(content.find("Item1,3,3.3\n"), std::string::npos);
+    EXPECT_NE(content.find("Item2,1,4.4\n"), std::string::npos);
+    EXPECT_NE(content.find("Item2,2,5.5\n"), std::string::npos);
 
     std::filesystem::remove(csv_path);
 }


### PR DESCRIPTION
- add "sep=," header
- do not rename `id` column to `label` in group tables
- keep `vector_index` for vector tables