### PR TITLE
updates in read_time_series_row: group arg, typed frees, null-safe strings

### DIFF
--- a/bindings/julia/src/c_api.jl
+++ b/bindings/julia/src/c_api.jl
@@ -302,12 +302,8 @@ function quiver_database_update_time_series_group(db, collection, group, id, col
     @ccall libquiver_c.quiver_database_update_time_series_group(db::Ptr{quiver_database_t}, collection::Ptr{Cchar}, group::Ptr{Cchar}, id::Int64, column_names::Ptr{Ptr{Cchar}}, column_types::Ptr{Cint}, column_data::Ptr{Ptr{Cvoid}}, column_count::Csize_t, row_count::Csize_t)::quiver_error_t
 end
 
-function quiver_database_read_time_series_row(db, collection, attribute, date_time, out_data_type, out_values, out_count)
-    @ccall libquiver_c.quiver_database_read_time_series_row(db::Ptr{quiver_database_t}, collection::Ptr{Cchar}, attribute::Ptr{Cchar}, date_time::Ptr{Cchar}, out_data_type::Ptr{Cint}, out_values::Ptr{Ptr{Cvoid}}, out_count::Ptr{Csize_t})::quiver_error_t
-end
-
-function quiver_database_free_time_series_row(data_type, values, count)
-    @ccall libquiver_c.quiver_database_free_time_series_row(data_type::Cint, values::Ptr{Cvoid}, count::Csize_t)::quiver_error_t
+function quiver_database_read_time_series_row(db, collection, group, attribute, date_time, out_data_type, out_values, out_count)
+    @ccall libquiver_c.quiver_database_read_time_series_row(db::Ptr{quiver_database_t}, collection::Ptr{Cchar}, group::Ptr{Cchar}, attribute::Ptr{Cchar}, date_time::Ptr{Cchar}, out_data_type::Ptr{Cint}, out_values::Ptr{Ptr{Cvoid}}, out_count::Ptr{Csize_t})::quiver_error_t
 end
 
 function quiver_database_free_time_series_data(column_names, column_types, column_data, column_count, row_count)

--- a/bindings/julia/src/database_read.jl
+++ b/bindings/julia/src/database_read.jl
@@ -579,7 +579,7 @@ function read_time_series_group(db::Database, collection::String, group::String,
     return result
 end
 
-function read_time_series_row(db::Database, collection::String, attribute::String; date_time::DateTime)
+function read_time_series_row(db::Database, collection::String, group::String, attribute::String; date_time::DateTime)
     out_data_type = Ref{Cint}(0)
     out_values = Ref{Ptr{Cvoid}}(C_NULL)
     out_count = Ref{Csize_t}(0)
@@ -588,7 +588,7 @@ function read_time_series_row(db::Database, collection::String, attribute::Strin
 
     check(
         C.quiver_database_read_time_series_row(
-            db.ptr, collection, attribute, dt_str,
+            db.ptr, collection, group, attribute, dt_str,
             out_data_type, out_values, out_count,
         ),
     )
@@ -602,28 +602,30 @@ function read_time_series_row(db::Database, collection::String, attribute::Strin
         elseif data_type == Cint(C.QUIVER_DATA_TYPE_FLOAT)
             return Float64[]
         elseif data_type == Cint(C.QUIVER_DATA_TYPE_STRING) || data_type == Cint(C.QUIVER_DATA_TYPE_DATE_TIME)
-            return String[]
+            return Union{String, Nothing}[]
         end
         return Any[]
     end
 
-    result = if data_type == Cint(C.QUIVER_DATA_TYPE_INTEGER)
+    if data_type == Cint(C.QUIVER_DATA_TYPE_INTEGER)
         int_ptr = reinterpret(Ptr{Int64}, out_values[])
-        copy(unsafe_wrap(Array, int_ptr, count))
+        result = copy(unsafe_wrap(Array, int_ptr, count))
+        C.quiver_database_free_integer_array(int_ptr)
+        return result
     elseif data_type == Cint(C.QUIVER_DATA_TYPE_FLOAT)
         float_ptr = reinterpret(Ptr{Float64}, out_values[])
-        copy(unsafe_wrap(Array, float_ptr, count))
+        result = copy(unsafe_wrap(Array, float_ptr, count))
+        C.quiver_database_free_float_array(float_ptr)
+        return result
     elseif data_type == Cint(C.QUIVER_DATA_TYPE_STRING) || data_type == Cint(C.QUIVER_DATA_TYPE_DATE_TIME)
         str_ptr_ptr = reinterpret(Ptr{Ptr{Cchar}}, out_values[])
         str_ptrs = unsafe_wrap(Array, str_ptr_ptr, count)
-        String[p == C_NULL ? "" : unsafe_string(p) for p in str_ptrs]
-    else
-        throw(ArgumentError("Unsupported data type $(data_type) for attribute '$attribute'"))
+        result = Union{String, Nothing}[p == C_NULL ? nothing : unsafe_string(p) for p in str_ptrs]
+        C.quiver_database_free_string_array(str_ptr_ptr, Csize_t(count))
+        return result
     end
 
-    C.quiver_database_free_time_series_row(Cint(data_type), out_values[], Csize_t(count))
-
-    return result
+    throw(ArgumentError("Unsupported data type $(data_type) for attribute '$attribute'"))
 end
 
 function read_time_series_files(db::Database, collection::String)

--- a/bindings/julia/test/test_database_time_series.jl
+++ b/bindings/julia/test/test_database_time_series.jl
@@ -375,14 +375,14 @@ include("fixture.jl")
         )
 
         # Query at 2024-01-02: Item 1 -> 2.0, Item 2 -> 20.0
-        result = Quiver.read_time_series_row(db, "Collection", "value"; date_time = DateTime(2024, 1, 2))
+        result = Quiver.read_time_series_row(db, "Collection", "data", "value"; date_time = DateTime(2024, 1, 2))
         @test result isa Vector{Float64}
         @test length(result) == 2
         @test result[1] == 2.0
         @test result[2] == 20.0
 
         # Query at 2024-01-03: Item 1 -> 3.0, Item 2 -> 20.0 (last at or before)
-        result2 = Quiver.read_time_series_row(db, "Collection", "value"; date_time = DateTime(2024, 1, 3))
+        result2 = Quiver.read_time_series_row(db, "Collection", "data", "value"; date_time = DateTime(2024, 1, 3))
         @test result2[1] == 3.0
         @test result2[2] == 20.0
 
@@ -407,14 +407,14 @@ include("fixture.jl")
         )
 
         # Query at 2024-01-02: Item 1 -> 2.0, Item 2 -> 10.0
-        result = Quiver.read_time_series_row(db, "Collection", "value"; date_time = DateTime(2024, 1, 2))
+        result = Quiver.read_time_series_row(db, "Collection", "data", "value"; date_time = DateTime(2024, 1, 2))
         @test result isa Vector{Float64}
         @test length(result) == 2
         @test result[1] == 2.0
         @test result[2] == 10.0
 
         # Query at 2024-01-03: Item 1 -> 3.0, Item 2 -> 10.0 (last at or before)
-        result2 = Quiver.read_time_series_row(db, "Collection", "value"; date_time = DateTime(2024, 1, 3))
+        result2 = Quiver.read_time_series_row(db, "Collection", "data", "value"; date_time = DateTime(2024, 1, 3))
         @test result2[1] == 3.0
         @test result2[2] == 10.0
 
@@ -434,7 +434,7 @@ include("fixture.jl")
         )
 
         # Query before any data: should return NaN for the float attribute
-        result = Quiver.read_time_series_row(db, "Collection", "value"; date_time = DateTime(2024, 1, 1))
+        result = Quiver.read_time_series_row(db, "Collection", "data", "value"; date_time = DateTime(2024, 1, 1))
         @test length(result) == 1
         @test isnan(result[1])
 
@@ -447,7 +447,7 @@ include("fixture.jl")
 
         Quiver.create_element!(db, "Configuration"; label = "Test Config")
 
-        result = Quiver.read_time_series_row(db, "Collection", "value"; date_time = DateTime(2024, 1, 1))
+        result = Quiver.read_time_series_row(db, "Collection", "data", "value"; date_time = DateTime(2024, 1, 1))
         @test isempty(result)
         @test result isa Vector{Float64}
 
@@ -468,7 +468,7 @@ include("fixture.jl")
         )
 
         # Item 1 has data, Item 2 doesn't (NaN sentinel)
-        result = Quiver.read_time_series_row(db, "Collection", "value"; date_time = DateTime(2024, 1, 1))
+        result = Quiver.read_time_series_row(db, "Collection", "data", "value"; date_time = DateTime(2024, 1, 1))
         @test length(result) == 2
         @test result[1] == 5.0
         @test isnan(result[2])
@@ -491,17 +491,17 @@ include("fixture.jl")
         )
 
         # Read humidity (INTEGER type)
-        humids = Quiver.read_time_series_row(db, "Sensor", "humidity"; date_time = DateTime(2024, 1, 2))
+        humids = Quiver.read_time_series_row(db, "Sensor", "readings", "humidity"; date_time = DateTime(2024, 1, 2))
         @test humids isa Vector{Int64}
         @test humids[1] == 70
 
         # Read status (STRING type)
-        stats = Quiver.read_time_series_row(db, "Sensor", "status"; date_time = DateTime(2024, 1, 1))
-        @test stats isa Vector{String}
+        stats = Quiver.read_time_series_row(db, "Sensor", "readings", "status"; date_time = DateTime(2024, 1, 1))
+        @test stats isa Vector{Union{String, Nothing}}
         @test stats[1] == "ok"
 
         # Read temperature (FLOAT type)
-        temps = Quiver.read_time_series_row(db, "Sensor", "temperature"; date_time = DateTime(2024, 1, 2))
+        temps = Quiver.read_time_series_row(db, "Sensor", "readings", "temperature"; date_time = DateTime(2024, 1, 2))
         @test temps isa Vector{Float64}
         @test temps[1] == 21.0
 
@@ -513,8 +513,44 @@ include("fixture.jl")
         db = Quiver.from_schema(":memory:", path_schema)
 
         @test_throws Quiver.DatabaseException Quiver.read_time_series_row(
-            db, "Collection", "nonexistent"; date_time = DateTime(2024, 1, 1),
+            db, "Collection", "data", "nonexistent"; date_time = DateTime(2024, 1, 1),
         )
+
+        Quiver.close!(db)
+    end
+
+    @testset "Read Time Series Row - Group Not Found" begin
+        path_schema = joinpath(tests_path(), "schemas", "valid", "collections.sql")
+        db = Quiver.from_schema(":memory:", path_schema)
+
+        @test_throws Quiver.DatabaseException Quiver.read_time_series_row(
+            db, "Collection", "nonexistent", "value"; date_time = DateTime(2024, 1, 1),
+        )
+
+        Quiver.close!(db)
+    end
+
+    @testset "Read Time Series Row - String Null Distinguished From Empty" begin
+        path_schema = joinpath(tests_path(), "schemas", "valid", "mixed_time_series.sql")
+        db = Quiver.from_schema(":memory:", path_schema)
+
+        Quiver.create_element!(db, "Configuration"; label = "Test Config")
+        id1 = Quiver.create_element!(db, "Sensor"; label = "Sensor 1")
+        Quiver.create_element!(db, "Sensor"; label = "Sensor 2")  # no data
+
+        Quiver.update_time_series_group!(db, "Sensor", "readings", id1;
+            date_time = ["2024-01-01T00:00:00"],
+            temperature = [20.0],
+            humidity = [50],
+            status = [""],  # empty string, not null
+        )
+
+        # Sensor 1 has "" (real value), Sensor 2 has no row (nothing)
+        result = Quiver.read_time_series_row(db, "Sensor", "readings", "status"; date_time = DateTime(2024, 1, 1))
+        @test result isa Vector{Union{String, Nothing}}
+        @test length(result) == 2
+        @test result[1] == ""
+        @test result[2] === nothing
 
         Quiver.close!(db)
     end

--- a/include/quiver/c/database.h
+++ b/include/quiver/c/database.h
@@ -305,17 +305,18 @@ QUIVER_C_API quiver_error_t quiver_database_update_time_series_group(quiver_data
 // out_values: typed array (int64_t* for INTEGER, double* for FLOAT, char** for STRING/DATE_TIME)
 // out_count: number of elements in the collection
 // For elements with no matching data: INTEGER -> 0, FLOAT -> NaN, STRING/DATE_TIME -> NULL pointer
+// Free out_values with the typed free function matching *out_data_type:
+//   INTEGER -> quiver_database_free_integer_array
+//   FLOAT -> quiver_database_free_float_array
+//   STRING/DATE_TIME -> quiver_database_free_string_array
 QUIVER_C_API quiver_error_t quiver_database_read_time_series_row(quiver_database_t* db,
                                                                  const char* collection,
+                                                                 const char* group,
                                                                  const char* attribute,
                                                                  const char* date_time,
                                                                  int* out_data_type,
                                                                  void** out_values,
                                                                  size_t* out_count);
-
-// Free time series row read results
-// Uses data_type to determine deallocation strategy
-QUIVER_C_API quiver_error_t quiver_database_free_time_series_row(int data_type, void* values, size_t count);
 
 // Free multi-column time series read results
 // Uses column_types to determine deallocation strategy per column

--- a/include/quiver/database.h
+++ b/include/quiver/database.h
@@ -106,8 +106,10 @@ public:
     // Read time series row - returns one value per element for a specific attribute at a given date_time
     // Uses "last non-null value at or before date_time" lookup semantics
     // Returns nullptr Value for elements with no matching data
-    std::vector<Value>
-    read_time_series_row(const std::string& collection, const std::string& attribute, const std::string& date_time);
+    std::vector<Value> read_time_series_row(const std::string& collection,
+                                            const std::string& group,
+                                            const std::string& attribute,
+                                            const std::string& date_time);
 
     // Update time series group - replaces all rows for element
     void update_time_series_group(const std::string& collection,

--- a/src/c/database_time_series.cpp
+++ b/src/c/database_time_series.cpp
@@ -3,7 +3,6 @@
 #include "quiver/c/database.h"
 #include "quiver/data_type.h"
 
-#include <cmath>
 #include <limits>
 #include <map>
 #include <optional>
@@ -58,35 +57,31 @@ QUIVER_C_API quiver_error_t quiver_database_list_time_series_groups(quiver_datab
 
 QUIVER_C_API quiver_error_t quiver_database_read_time_series_row(quiver_database_t* db,
                                                                  const char* collection,
+                                                                 const char* group,
                                                                  const char* attribute,
                                                                  const char* date_time,
                                                                  int* out_data_type,
                                                                  void** out_values,
                                                                  size_t* out_count) {
-    QUIVER_REQUIRE(db, collection, attribute, date_time, out_data_type, out_values, out_count);
+    QUIVER_REQUIRE(db, collection, group, attribute, date_time, out_data_type, out_values, out_count);
 
     try {
-        // Look up the attribute's data type from time series metadata
-        auto groups = db->db.list_time_series_groups(collection);
+        auto metadata = db->db.get_time_series_metadata(collection, group);
         quiver::DataType attr_type{};
         bool found = false;
-        for (const auto& group : groups) {
-            for (const auto& vc : group.value_columns) {
-                if (vc.name == attribute) {
-                    attr_type = vc.data_type;
-                    found = true;
-                    break;
-                }
-            }
-            if (found)
+        for (const auto& vc : metadata.value_columns) {
+            if (vc.name == attribute) {
+                attr_type = vc.data_type;
+                found = true;
                 break;
+            }
         }
         if (!found) {
-            throw std::runtime_error("Time series attribute not found: '" + std::string(attribute) +
-                                     "' in collection '" + std::string(collection) + "'");
+            throw std::runtime_error("Time series attribute not found: '" + std::string(attribute) + "' in group '" +
+                                     std::string(group) + "' of collection '" + std::string(collection) + "'");
         }
 
-        auto values = db->db.read_time_series_row(collection, attribute, date_time);
+        auto values = db->db.read_time_series_row(collection, group, attribute, date_time);
         *out_count = values.size();
         *out_data_type = to_c_data_type(attr_type);
 
@@ -99,11 +94,7 @@ QUIVER_C_API quiver_error_t quiver_database_read_time_series_row(quiver_database
         case QUIVER_DATA_TYPE_INTEGER: {
             auto* arr = new int64_t[values.size()];
             for (size_t i = 0; i < values.size(); ++i) {
-                if (std::holds_alternative<int64_t>(values[i])) {
-                    arr[i] = std::get<int64_t>(values[i]);
-                } else {
-                    arr[i] = 0;  // null sentinel
-                }
+                arr[i] = std::holds_alternative<int64_t>(values[i]) ? std::get<int64_t>(values[i]) : 0;
             }
             *out_values = arr;
             break;
@@ -111,11 +102,8 @@ QUIVER_C_API quiver_error_t quiver_database_read_time_series_row(quiver_database
         case QUIVER_DATA_TYPE_FLOAT: {
             auto* arr = new double[values.size()];
             for (size_t i = 0; i < values.size(); ++i) {
-                if (std::holds_alternative<double>(values[i])) {
-                    arr[i] = std::get<double>(values[i]);
-                } else {
-                    arr[i] = std::numeric_limits<double>::quiet_NaN();  // null sentinel
-                }
+                arr[i] = std::holds_alternative<double>(values[i]) ? std::get<double>(values[i])
+                                                                   : std::numeric_limits<double>::quiet_NaN();
             }
             *out_values = arr;
             break;
@@ -124,11 +112,9 @@ QUIVER_C_API quiver_error_t quiver_database_read_time_series_row(quiver_database
         case QUIVER_DATA_TYPE_DATE_TIME: {
             auto** arr = new char*[values.size()];
             for (size_t i = 0; i < values.size(); ++i) {
-                if (std::holds_alternative<std::string>(values[i])) {
-                    arr[i] = quiver::string::new_c_str(std::get<std::string>(values[i]));
-                } else {
-                    arr[i] = nullptr;  // null sentinel
-                }
+                arr[i] = std::holds_alternative<std::string>(values[i])
+                             ? quiver::string::new_c_str(std::get<std::string>(values[i]))
+                             : nullptr;
             }
             *out_values = arr;
             break;
@@ -143,35 +129,6 @@ QUIVER_C_API quiver_error_t quiver_database_read_time_series_row(quiver_database
         quiver_set_last_error(e.what());
         return QUIVER_ERROR;
     }
-}
-
-QUIVER_C_API quiver_error_t quiver_database_free_time_series_row(int data_type, void* values, size_t count) {
-    if (!values) {
-        return QUIVER_OK;
-    }
-
-    switch (data_type) {
-    case QUIVER_DATA_TYPE_INTEGER:
-        delete[] static_cast<int64_t*>(values);
-        break;
-    case QUIVER_DATA_TYPE_FLOAT:
-        delete[] static_cast<double*>(values);
-        break;
-    case QUIVER_DATA_TYPE_STRING:
-    case QUIVER_DATA_TYPE_DATE_TIME: {
-        auto** strings = static_cast<char**>(values);
-        for (size_t i = 0; i < count; ++i) {
-            delete[] strings[i];
-        }
-        delete[] strings;
-        break;
-    }
-    default:
-        quiver_set_last_error("Cannot free_time_series_row: unknown data type " + std::to_string(data_type));
-        return QUIVER_ERROR;
-    }
-
-    return QUIVER_OK;
 }
 
 // Time series read/update

--- a/src/database_time_series.cpp
+++ b/src/database_time_series.cpp
@@ -205,80 +205,72 @@ void Database::update_time_series_group(const std::string& collection,
 }
 
 std::vector<Value> Database::read_time_series_row(const std::string& collection,
+                                                  const std::string& group,
                                                   const std::string& attribute,
                                                   const std::string& date_time) {
     impl_->require_collection(collection, "read_time_series_row");
 
-    // Find which time series group contains this attribute (search value columns only)
-    auto groups = list_time_series_groups(collection);
-    std::string target_group;
-    std::string dim_col;
-
-    for (const auto& group : groups) {
-        for (const auto& vc : group.value_columns) {
-            if (vc.name == attribute) {
-                target_group = group.group_name;
-                dim_col = group.dimension_column;
-                break;
-            }
-        }
-        if (!target_group.empty())
-            break;
+    auto ts_table = impl_->schema->find_time_series_table(collection, group);
+    const auto* table_def = impl_->schema->get_table(ts_table);
+    if (!table_def) {
+        throw std::runtime_error("Time series table not found: " + ts_table);
     }
+    auto dim_col = internal::find_dimension_column(*table_def);
 
-    if (target_group.empty()) {
-        throw std::runtime_error("Time series attribute not found: '" + attribute + "' in collection '" + collection +
-                                 "'");
+    const auto* attr_col = table_def->get_column(attribute);
+    if (!attr_col || attribute == "id" || attribute == dim_col) {
+        throw std::runtime_error("Time series attribute not found: '" + attribute + "' in group '" + group +
+                                 "' of collection '" + collection + "'");
     }
+    auto attr_type = attr_col->type;
 
-    auto ts_table = Schema::time_series_table_name(collection, target_group);
-
-    // Get all element IDs in order
     auto element_ids = read_element_ids(collection);
     if (element_ids.empty()) {
         return {};
     }
 
-    // For each element, find the most recent non-null value where dim_col <= date_time
-    // Uses a self-join: subquery finds the max dim_col per id, outer query gets the value
-    auto sql = "SELECT t.id, t." + attribute + " FROM " + ts_table + " t " + "INNER JOIN (SELECT id, MAX(" + dim_col +
-               ") as max_dt " + "FROM " + ts_table + " WHERE " + dim_col + " <= ? AND " + attribute + " IS NOT NULL " +
-               "GROUP BY id) latest " + "ON t.id = latest.id AND t." + dim_col + " = latest.max_dt " + "ORDER BY t.id";
+    // For each element, find the most recent non-null value where dim_col <= date_time.
+    // Self-join: subquery picks max dim_col per id, outer query gets the value.
+    auto sql = "SELECT t.id, t." + attribute + " FROM " + ts_table + " t INNER JOIN (SELECT id, MAX(" + dim_col +
+               ") as max_dt FROM " + ts_table + " WHERE " + dim_col + " <= ? AND " + attribute + " IS NOT NULL " +
+               "GROUP BY id) latest ON t.id = latest.id AND t." + dim_col + " = latest.max_dt ORDER BY t.id";
 
     auto query_result = execute(sql, {date_time});
 
-    // Build id -> value map from results
     std::map<int64_t, Value> id_value_map;
     for (size_t i = 0; i < query_result.row_count(); ++i) {
         auto id = query_result[i].get_integer(0);
         if (!id)
             continue;
 
-        auto int_val = query_result[i].get_integer(1);
-        auto float_val = query_result[i].get_float(1);
-        auto str_val = query_result[i].get_string(1);
-
-        if (int_val) {
-            id_value_map[*id] = *int_val;
-        } else if (float_val) {
-            id_value_map[*id] = *float_val;
-        } else if (str_val) {
-            id_value_map[*id] = *str_val;
-        } else {
-            id_value_map[*id] = nullptr;
+        switch (attr_type) {
+        case DataType::Integer:
+            if (auto v = query_result[i].get_integer(1))
+                id_value_map[*id] = *v;
+            else
+                id_value_map[*id] = nullptr;
+            break;
+        case DataType::Real:
+            if (auto v = query_result[i].get_float(1))
+                id_value_map[*id] = *v;
+            else
+                id_value_map[*id] = nullptr;
+            break;
+        case DataType::Text:
+        case DataType::DateTime:
+            if (auto v = query_result[i].get_string(1))
+                id_value_map[*id] = *v;
+            else
+                id_value_map[*id] = nullptr;
+            break;
         }
     }
 
-    // Build result vector in element ID order (nullptr for missing elements)
     std::vector<Value> result;
     result.reserve(element_ids.size());
     for (auto element_id : element_ids) {
         auto it = id_value_map.find(element_id);
-        if (it != id_value_map.end()) {
-            result.push_back(it->second);
-        } else {
-            result.push_back(nullptr);
-        }
+        result.push_back(it != id_value_map.end() ? it->second : Value{nullptr});
     }
 
     return result;

--- a/tests/test_c_api_database_time_series.cpp
+++ b/tests/test_c_api_database_time_series.cpp
@@ -952,7 +952,7 @@ TEST(DatabaseCApi, ReadTimeSeriesRow) {
     void* out_values = nullptr;
     size_t out_count = 0;
     auto err = quiver_database_read_time_series_row(
-        db, "Collection", "value", "2024-01-02", &out_type, &out_values, &out_count);
+        db, "Collection", "data", "value", "2024-01-02", &out_type, &out_values, &out_count);
     EXPECT_EQ(err, QUIVER_OK);
     EXPECT_EQ(out_type, QUIVER_DATA_TYPE_FLOAT);
     ASSERT_EQ(out_count, 2);
@@ -961,11 +961,11 @@ TEST(DatabaseCApi, ReadTimeSeriesRow) {
     EXPECT_DOUBLE_EQ(floats[0], 2.0);
     EXPECT_DOUBLE_EQ(floats[1], 20.0);
 
-    quiver_database_free_time_series_row(out_type, out_values, out_count);
+    quiver_database_free_float_array(floats);
 
     // Read at 2024-01-03: Item 1 -> 3.0, Item 2 -> 20.0 (last at or before)
     err = quiver_database_read_time_series_row(
-        db, "Collection", "value", "2024-01-03", &out_type, &out_values, &out_count);
+        db, "Collection", "data", "value", "2024-01-03", &out_type, &out_values, &out_count);
     EXPECT_EQ(err, QUIVER_OK);
     ASSERT_EQ(out_count, 2);
 
@@ -973,7 +973,7 @@ TEST(DatabaseCApi, ReadTimeSeriesRow) {
     EXPECT_DOUBLE_EQ(floats[0], 3.0);
     EXPECT_DOUBLE_EQ(floats[1], 20.0);
 
-    quiver_database_free_time_series_row(out_type, out_values, out_count);
+    quiver_database_free_float_array(floats);
     quiver_database_close(db);
 }
 
@@ -1011,7 +1011,7 @@ TEST(DatabaseCApi, ReadTimeSeriesRowBeforeAllData) {
     void* out_values = nullptr;
     size_t out_count = 0;
     auto err = quiver_database_read_time_series_row(
-        db, "Collection", "value", "2024-01-01", &out_type, &out_values, &out_count);
+        db, "Collection", "data", "value", "2024-01-01", &out_type, &out_values, &out_count);
     EXPECT_EQ(err, QUIVER_OK);
     ASSERT_EQ(out_count, 1);
     EXPECT_EQ(out_type, QUIVER_DATA_TYPE_FLOAT);
@@ -1019,7 +1019,7 @@ TEST(DatabaseCApi, ReadTimeSeriesRowBeforeAllData) {
     auto* floats = static_cast<double*>(out_values);
     EXPECT_TRUE(std::isnan(floats[0]));
 
-    quiver_database_free_time_series_row(out_type, out_values, out_count);
+    quiver_database_free_float_array(floats);
     quiver_database_close(db);
 }
 
@@ -1042,7 +1042,7 @@ TEST(DatabaseCApi, ReadTimeSeriesRowEmptyCollection) {
     void* out_values = nullptr;
     size_t out_count = 0;
     auto err = quiver_database_read_time_series_row(
-        db, "Collection", "value", "2024-01-01", &out_type, &out_values, &out_count);
+        db, "Collection", "data", "value", "2024-01-01", &out_type, &out_values, &out_count);
     EXPECT_EQ(err, QUIVER_OK);
     EXPECT_EQ(out_count, 0);
     EXPECT_EQ(out_values, nullptr);
@@ -1087,7 +1087,7 @@ TEST(DatabaseCApi, ReadTimeSeriesRowMultiColumnInteger) {
     void* out_values = nullptr;
     size_t out_count = 0;
     auto err = quiver_database_read_time_series_row(
-        db, "Sensor", "humidity", "2024-01-02", &out_type, &out_values, &out_count);
+        db, "Sensor", "readings", "humidity", "2024-01-02", &out_type, &out_values, &out_count);
     EXPECT_EQ(err, QUIVER_OK);
     EXPECT_EQ(out_type, QUIVER_DATA_TYPE_INTEGER);
     ASSERT_EQ(out_count, 1);
@@ -1095,11 +1095,11 @@ TEST(DatabaseCApi, ReadTimeSeriesRowMultiColumnInteger) {
     auto* ints = static_cast<int64_t*>(out_values);
     EXPECT_EQ(ints[0], 70);
 
-    quiver_database_free_time_series_row(out_type, out_values, out_count);
+    quiver_database_free_integer_array(ints);
 
     // Read status (STRING) at 2024-01-01
-    err =
-        quiver_database_read_time_series_row(db, "Sensor", "status", "2024-01-01", &out_type, &out_values, &out_count);
+    err = quiver_database_read_time_series_row(
+        db, "Sensor", "readings", "status", "2024-01-01", &out_type, &out_values, &out_count);
     EXPECT_EQ(err, QUIVER_OK);
     EXPECT_EQ(out_type, QUIVER_DATA_TYPE_STRING);
     ASSERT_EQ(out_count, 1);
@@ -1107,7 +1107,7 @@ TEST(DatabaseCApi, ReadTimeSeriesRowMultiColumnInteger) {
     auto** strings = static_cast<char**>(out_values);
     EXPECT_STREQ(strings[0], "ok");
 
-    quiver_database_free_time_series_row(out_type, out_values, out_count);
+    quiver_database_free_string_array(strings, out_count);
     quiver_database_close(db);
 }
 
@@ -1123,26 +1123,29 @@ TEST(DatabaseCApi, ReadTimeSeriesRowNullArguments) {
     size_t out_count = 0;
 
     EXPECT_EQ(quiver_database_read_time_series_row(
-                  nullptr, "Collection", "value", "2024-01-01", &out_type, &out_values, &out_count),
+                  nullptr, "Collection", "data", "value", "2024-01-01", &out_type, &out_values, &out_count),
               QUIVER_ERROR);
-    EXPECT_EQ(
-        quiver_database_read_time_series_row(db, nullptr, "value", "2024-01-01", &out_type, &out_values, &out_count),
-        QUIVER_ERROR);
     EXPECT_EQ(quiver_database_read_time_series_row(
-                  db, "Collection", nullptr, "2024-01-01", &out_type, &out_values, &out_count),
+                  db, nullptr, "data", "value", "2024-01-01", &out_type, &out_values, &out_count),
               QUIVER_ERROR);
-    EXPECT_EQ(
-        quiver_database_read_time_series_row(db, "Collection", "value", nullptr, &out_type, &out_values, &out_count),
-        QUIVER_ERROR);
-    EXPECT_EQ(
-        quiver_database_read_time_series_row(db, "Collection", "value", "2024-01-01", nullptr, &out_values, &out_count),
-        QUIVER_ERROR);
-    EXPECT_EQ(
-        quiver_database_read_time_series_row(db, "Collection", "value", "2024-01-01", &out_type, nullptr, &out_count),
-        QUIVER_ERROR);
-    EXPECT_EQ(
-        quiver_database_read_time_series_row(db, "Collection", "value", "2024-01-01", &out_type, &out_values, nullptr),
-        QUIVER_ERROR);
+    EXPECT_EQ(quiver_database_read_time_series_row(
+                  db, "Collection", nullptr, "value", "2024-01-01", &out_type, &out_values, &out_count),
+              QUIVER_ERROR);
+    EXPECT_EQ(quiver_database_read_time_series_row(
+                  db, "Collection", "data", nullptr, "2024-01-01", &out_type, &out_values, &out_count),
+              QUIVER_ERROR);
+    EXPECT_EQ(quiver_database_read_time_series_row(
+                  db, "Collection", "data", "value", nullptr, &out_type, &out_values, &out_count),
+              QUIVER_ERROR);
+    EXPECT_EQ(quiver_database_read_time_series_row(
+                  db, "Collection", "data", "value", "2024-01-01", nullptr, &out_values, &out_count),
+              QUIVER_ERROR);
+    EXPECT_EQ(quiver_database_read_time_series_row(
+                  db, "Collection", "data", "value", "2024-01-01", &out_type, nullptr, &out_count),
+              QUIVER_ERROR);
+    EXPECT_EQ(quiver_database_read_time_series_row(
+                  db, "Collection", "data", "value", "2024-01-01", &out_type, &out_values, nullptr),
+              QUIVER_ERROR);
 
     quiver_database_close(db);
 }
@@ -1158,7 +1161,7 @@ TEST(DatabaseCApi, ReadTimeSeriesRowAttributeNotFound) {
     void* out_values = nullptr;
     size_t out_count = 0;
     auto err = quiver_database_read_time_series_row(
-        db, "Collection", "nonexistent", "2024-01-01", &out_type, &out_values, &out_count);
+        db, "Collection", "data", "nonexistent", "2024-01-01", &out_type, &out_values, &out_count);
     EXPECT_EQ(err, QUIVER_ERROR);
     std::string msg = quiver_get_last_error();
     EXPECT_NE(msg.find("Time series attribute not found"), std::string::npos) << "Actual: " << msg;
@@ -1166,11 +1169,23 @@ TEST(DatabaseCApi, ReadTimeSeriesRowAttributeNotFound) {
     quiver_database_close(db);
 }
 
-TEST(DatabaseCApi, FreeTimeSeriesRowNull) {
-    // Free with NULL values - should succeed
-    EXPECT_EQ(quiver_database_free_time_series_row(QUIVER_DATA_TYPE_FLOAT, nullptr, 0), QUIVER_OK);
-    EXPECT_EQ(quiver_database_free_time_series_row(QUIVER_DATA_TYPE_INTEGER, nullptr, 0), QUIVER_OK);
-    EXPECT_EQ(quiver_database_free_time_series_row(QUIVER_DATA_TYPE_STRING, nullptr, 0), QUIVER_OK);
+TEST(DatabaseCApi, ReadTimeSeriesRowGroupNotFound) {
+    auto options = quiver_database_options_default();
+    options.console_level = QUIVER_LOG_OFF;
+    quiver_database_t* db = nullptr;
+    ASSERT_EQ(quiver_database_from_schema(":memory:", VALID_SCHEMA("collections.sql").c_str(), &options, &db),
+              QUIVER_OK);
+
+    int out_type = 0;
+    void* out_values = nullptr;
+    size_t out_count = 0;
+    auto err = quiver_database_read_time_series_row(
+        db, "Collection", "nonexistent", "value", "2024-01-01", &out_type, &out_values, &out_count);
+    EXPECT_EQ(err, QUIVER_ERROR);
+    std::string msg = quiver_get_last_error();
+    EXPECT_NE(msg.find("not found"), std::string::npos) << "Actual: " << msg;
+
+    quiver_database_close(db);
 }
 
 TEST(DatabaseCApi, FreeTimeSeriesDataNull) {

--- a/tests/test_database_time_series.cpp
+++ b/tests/test_database_time_series.cpp
@@ -233,13 +233,13 @@ TEST(Database, ReadTimeSeriesRow) {
                                  {{"date_time", std::string("2024-01-02")}, {"value", 20.0}}});
 
     // Query at 2024-01-02: Item 1 -> 2.0, Item 2 -> 20.0
-    auto result = db.read_time_series_row("Collection", "value", "2024-01-02");
+    auto result = db.read_time_series_row("Collection", "data", "value", "2024-01-02");
     ASSERT_EQ(result.size(), 2);
     EXPECT_DOUBLE_EQ(std::get<double>(result[0]), 2.0);
     EXPECT_DOUBLE_EQ(std::get<double>(result[1]), 20.0);
 
     // Query at 2024-01-03: Item 1 -> 3.0, Item 2 -> 20.0 (last value at or before)
-    auto result2 = db.read_time_series_row("Collection", "value", "2024-01-03");
+    auto result2 = db.read_time_series_row("Collection", "data", "value", "2024-01-03");
     ASSERT_EQ(result2.size(), 2);
     EXPECT_DOUBLE_EQ(std::get<double>(result2[0]), 3.0);
     EXPECT_DOUBLE_EQ(std::get<double>(result2[1]), 20.0);
@@ -277,13 +277,13 @@ TEST(Database, ReadTimeSeriesRowWithMissingElements) {
                                  {{"date_time", std::string("2024-01-04")}, {"value", 20.0}}});
 
     // Query at 2024-01-02: Item 1 -> 2.0, Item 2 -> 10.0
-    auto result = db.read_time_series_row("Collection", "value", "2024-01-02");
+    auto result = db.read_time_series_row("Collection", "data", "value", "2024-01-02");
     ASSERT_EQ(result.size(), 2);
     EXPECT_DOUBLE_EQ(std::get<double>(result[0]), 2.0);
     EXPECT_DOUBLE_EQ(std::get<double>(result[1]), 10.0);
 
     // Query at 2024-01-03: Item 1 -> 3.0, Item 2 -> 10.0 (last value at or before)
-    auto result2 = db.read_time_series_row("Collection", "value", "2024-01-03");
+    auto result2 = db.read_time_series_row("Collection", "data", "value", "2024-01-03");
     ASSERT_EQ(result2.size(), 2);
     EXPECT_DOUBLE_EQ(std::get<double>(result2[0]), 3.0);
     EXPECT_DOUBLE_EQ(std::get<double>(result2[1]), 10.0);
@@ -305,7 +305,7 @@ TEST(Database, ReadTimeSeriesRowBeforeAllData) {
         "Collection", "data", id1, {{{"date_time", std::string("2024-01-02")}, {"value", 1.0}}});
 
     // Query before any data exists: should return nullptr for the element
-    auto result = db.read_time_series_row("Collection", "value", "2024-01-01");
+    auto result = db.read_time_series_row("Collection", "data", "value", "2024-01-01");
     ASSERT_EQ(result.size(), 1);
     EXPECT_TRUE(std::holds_alternative<std::nullptr_t>(result[0]));
 }
@@ -319,7 +319,7 @@ TEST(Database, ReadTimeSeriesRowEmptyCollection) {
     db.create_element("Configuration", config);
 
     // No elements in Collection -> empty result
-    auto result = db.read_time_series_row("Collection", "value", "2024-01-01");
+    auto result = db.read_time_series_row("Collection", "data", "value", "2024-01-01");
     EXPECT_TRUE(result.empty());
 }
 
@@ -343,7 +343,7 @@ TEST(Database, ReadTimeSeriesRowMixedElements) {
         "Collection", "data", id1, {{{"date_time", std::string("2024-01-01")}, {"value", 5.0}}});
 
     // Item 1 has data, Item 2 doesn't
-    auto result = db.read_time_series_row("Collection", "value", "2024-01-01");
+    auto result = db.read_time_series_row("Collection", "data", "value", "2024-01-01");
     ASSERT_EQ(result.size(), 2);
     EXPECT_DOUBLE_EQ(std::get<double>(result[0]), 5.0);
     EXPECT_TRUE(std::holds_alternative<std::nullptr_t>(result[1]));
@@ -353,7 +353,14 @@ TEST(Database, ReadTimeSeriesRowAttributeNotFound) {
     auto db = quiver::Database::from_schema(
         ":memory:", VALID_SCHEMA("collections.sql"), {.read_only = false, .console_level = quiver::LogLevel::Off});
 
-    EXPECT_THROW(db.read_time_series_row("Collection", "nonexistent", "2024-01-01"), std::runtime_error);
+    EXPECT_THROW(db.read_time_series_row("Collection", "data", "nonexistent", "2024-01-01"), std::runtime_error);
+}
+
+TEST(Database, ReadTimeSeriesRowGroupNotFound) {
+    auto db = quiver::Database::from_schema(
+        ":memory:", VALID_SCHEMA("collections.sql"), {.read_only = false, .console_level = quiver::LogLevel::Off});
+
+    EXPECT_THROW(db.read_time_series_row("Collection", "nonexistent", "value", "2024-01-01"), std::runtime_error);
 }
 
 TEST(Database, ReadTimeSeriesRowMultiColumn) {
@@ -382,17 +389,17 @@ TEST(Database, ReadTimeSeriesRowMultiColumn) {
                                   {"status", std::string("warn")}}});
 
     // Read temperature (REAL) at 2024-01-01
-    auto temps = db.read_time_series_row("Sensor", "temperature", "2024-01-01");
+    auto temps = db.read_time_series_row("Sensor", "readings", "temperature", "2024-01-01");
     ASSERT_EQ(temps.size(), 1);
     EXPECT_DOUBLE_EQ(std::get<double>(temps[0]), 20.5);
 
     // Read humidity (INTEGER) at 2024-01-02
-    auto humids = db.read_time_series_row("Sensor", "humidity", "2024-01-02");
+    auto humids = db.read_time_series_row("Sensor", "readings", "humidity", "2024-01-02");
     ASSERT_EQ(humids.size(), 1);
     EXPECT_EQ(std::get<int64_t>(humids[0]), 70);
 
     // Read status (TEXT) at 2024-01-02
-    auto stats = db.read_time_series_row("Sensor", "status", "2024-01-02");
+    auto stats = db.read_time_series_row("Sensor", "readings", "status", "2024-01-02");
     ASSERT_EQ(stats.size(), 1);
     EXPECT_EQ(std::get<std::string>(stats[0]), "warn");
 }
@@ -417,7 +424,7 @@ TEST(Database, ReadTimeSeriesRowSkipsNullValues) {
                                  {{"date_time", std::string("2024-01-02")}, {"value", nullptr}}});
 
     // Query at 01-02: should find the non-null value at 01-01 (skips null at 01-02)
-    auto result = db.read_time_series_row("Collection", "value", "2024-01-02");
+    auto result = db.read_time_series_row("Collection", "data", "value", "2024-01-02");
     ASSERT_EQ(result.size(), 1);
     EXPECT_DOUBLE_EQ(std::get<double>(result[0]), 5.0);
 }


### PR DESCRIPTION
Follow-up fixes to the `read_time_series_row` PR based on code review. Breaking API change.

  - **Add `group` argument.** Signature is now `read_time_series_row(collection, group, attribute, date_time)`, matching
  `read_time_series_group`. Removes the silent first-match-wins lookup when two groups shared a column name.
  - **Drop duplicated metadata walks.** C++ uses `Schema::find_time_series_table` once; the C API uses `get_time_series_metadata`
  once. Prior code walked `list_time_series_groups` twice per call.
  - **Dispatch on the known `DataType`.** Replaces the try-integer-then-float-then-string fallback with one switch arm per type,
  using `attr_col->type` captured during column lookup.
  - **Julia: distinguish null from empty string.** String/DateTime reads now return `Vector{Union{String, Nothing}}` instead of
  `Vector{String}` with `""` sentinels.
  - **Drop `quiver_database_free_time_series_row`.** Callers route `out_values` to the existing typed free helpers
  (`quiver_database_free_integer_array` / `_float_array` / `_string_array`) based on `out_data_type`.